### PR TITLE
Import

### DIFF
--- a/lake.lua
+++ b/lake.lua
@@ -49,7 +49,7 @@ return function(args)
     exec = exec,
     vexec = function(command) exec(command, true) end,
     include = include,
-    import = function(file) include(file, environment) end,
+    import = function(file) return include(file, environment) end,
     files_from_directory = require './src/util/files_from_directory',
     map = require './src/util/map',
     set_extension = require './src/util/set_extension',

--- a/sample/assemble.lk
+++ b/sample/assemble.lk
@@ -1,7 +1,11 @@
-rule('build/*.o', { '*.s', 'build' }, function(args)
-  print('Assembling ' .. args.target .. ' with generic rule...')
-  fs.mkdirp(path.dirname(args.target))
-  exec('touch ' .. args.target)
-  exec('sleep 0.25')
-  print('Finished assembling ' .. args.target)
-end)
+return function(config)
+  local build_dir = config.build_dir
+
+  rule(build_dir .. '/*.o', { '*.s', build_dir }, function(args)
+    print('Assembling ' .. args.target .. ' with generic rule...')
+    fs.mkdirp(path.dirname(args.target))
+    exec('touch ' .. args.target)
+    exec('sleep 0.25')
+    print('Finished assembling ' .. args.target)
+  end)
+end

--- a/sample/compile.lk
+++ b/sample/compile.lk
@@ -1,8 +1,12 @@
-rule('build/*.o', { '*.c', 'build' }, function(args)
-  print('Compiling ' .. args.target .. ' with generic rule...')
-  fs.mkdirp(path.dirname(args.target))
-  exec('touch ' .. args.target)
-  fs.writeFile('build/' .. args.match .. '.d', args.deps[1] .. ':' .. args.match .. '.h')
-  exec('sleep 0.25')
-  print('Finished compiling ' .. args.target)
-end)
+return function(config)
+  local build_dir = config.build_dir
+
+  rule(build_dir .. '/*.o', { '*.c', build_dir }, function(args)
+    print('Compiling ' .. args.target .. ' with generic rule...')
+    fs.mkdirp(path.dirname(args.target))
+    exec('touch ' .. args.target)
+    fs.writeFile(build_dir .. '/' .. args.match .. '.d', args.deps[1] .. ':' .. args.match .. '.h')
+    exec('sleep 0.25')
+    print('Finished compiling ' .. args.target)
+  end)
+end

--- a/sample/sample.lk
+++ b/sample/sample.lk
@@ -6,8 +6,8 @@ target('clean', {}, function()
   print('Finished cleaning')
 end)
 
-include('./compile.lk')
-include('./assemble.lk')
+import('./compile.lk')({ build_dir = 'build' })
+import('./assemble.lk')({ build_dir = 'build' })
 
 local source_patterns = { '%.c$', '%.s$' }
 local source_directories = { 'src', 'lib' }

--- a/spec/util/include_helper.lua
+++ b/spec/util/include_helper.lua
@@ -2,3 +2,4 @@ foo(1, 2, 3)
 if bar then
   bar('a', 'b', 'c')
 end
+return 5

--- a/spec/util/include_helper.lua
+++ b/spec/util/include_helper.lua
@@ -1,2 +1,4 @@
 foo(1, 2, 3)
-bar('a', 'b', 'c')
+if bar then
+  bar('a', 'b', 'c')
+end

--- a/spec/util/include_helper.lua
+++ b/spec/util/include_helper.lua
@@ -2,4 +2,5 @@ foo(1, 2, 3)
 if bar then
   bar('a', 'b', 'c')
 end
+baz = 6
 return 5

--- a/spec/util/include_spec.lua
+++ b/spec/util/include_spec.lua
@@ -38,4 +38,10 @@ describe('util.include', function()
     assert.spy(env.foo).was_called_with(1, 2, 3)
     assert.spy(bar).was_not_called()
   end)
+
+  it('should return the return value of the included file', function()
+    local foo = spy.new(load'')
+
+    assert.are.equal(5, include('spec/util/include_helper.lua'))
+  end)
 end)

--- a/spec/util/include_spec.lua
+++ b/spec/util/include_spec.lua
@@ -1,7 +1,9 @@
 describe('util.include', function()
   local include = require 'util.include'
 
-  bar = spy.new(load'')
+  before_each(function()
+    bar = spy.new(load'')
+  end)
 
   it('should load the specified file in the current environment', function()
     local foo = spy.new(load'')
@@ -17,5 +19,23 @@ describe('util.include', function()
     include('./include_helper.lua')
     assert.spy(foo).was_called_with(1, 2, 3)
     assert.spy(bar).was_called_with('a', 'b', 'c')
+  end)
+
+  it('should load a relative file in the current environment', function()
+    local foo = spy.new(load'')
+
+    include('./include_helper.lua')
+    assert.spy(foo).was_called_with(1, 2, 3)
+    assert.spy(bar).was_called_with('a', 'b', 'c')
+  end)
+
+  it('should allow a file to be loaded with a custom environment', function()
+    local env = {
+      foo = spy.new(load'')
+    }
+
+    include('./include_helper.lua', env)
+    assert.spy(env.foo).was_called_with(1, 2, 3)
+    assert.spy(bar).was_not_called()
   end)
 end)

--- a/spec/util/include_spec.lua
+++ b/spec/util/include_spec.lua
@@ -39,6 +39,27 @@ describe('util.include', function()
     assert.spy(bar).was_not_called()
   end)
 
+  it('should not include locals in custom environments', function()
+    local env = {
+      foo = spy.new(load'')
+    }
+    local bar = spy.new(load'')
+
+    include('./include_helper.lua', env)
+    assert.spy(env.foo).was_called_with(1, 2, 3)
+    assert.spy(bar).was_not_called()
+  end)
+
+  it('should not allow the loaded file to modify a custom environment', function()
+    local env = {
+      foo = spy.new(load'')
+    }
+    local bar = spy.new(load'')
+
+    include('./include_helper.lua', env)
+    assert.is_nil(env.baz)
+  end)
+
   it('should return the return value of the included file', function()
     local foo = spy.new(load'')
 

--- a/src/util/include.lua
+++ b/src/util/include.lua
@@ -18,7 +18,7 @@ return function(file, environment)
     local current_directory = debug.getinfo(2, 'S').source:sub(2):match('(.*/)') or ''
     file = current_directory .. file:match('^./(.+)')
   end
-  setfenv(loadfile(file), setmetatable(locals(), {
+  return setfenv(loadfile(file), setmetatable(locals(), {
     __index = environment or getfenv(2)
   }))()
 end

--- a/src/util/include.lua
+++ b/src/util/include.lua
@@ -18,7 +18,13 @@ return function(file, environment)
     local current_directory = debug.getinfo(2, 'S').source:sub(2):match('(.*/)') or ''
     file = current_directory .. file:match('^./(.+)')
   end
-  return setfenv(loadfile(file), setmetatable(locals(), {
-    __index = environment or getfenv(2)
-  }))()
+  if environment then
+    return setfenv(loadfile(file), setmetatable({}, {
+      __index = environment
+    }))()
+  else
+    return setfenv(loadfile(file), setmetatable(locals(), {
+      __index = getfenv(2)
+    }))()
+  end
 end

--- a/src/util/include.lua
+++ b/src/util/include.lua
@@ -13,12 +13,12 @@ local function locals()
   return locals
 end
 
-return function(file)
+return function(file, environment)
   if file:match('^./') then
     local current_directory = debug.getinfo(2, 'S').source:sub(2):match('(.*/)') or ''
     file = current_directory .. file:match('^./(.+)')
   end
   setfenv(loadfile(file), setmetatable(locals(), {
-    __index = getfenv(2)
+    __index = environment or getfenv(2)
   }))()
 end


### PR DESCRIPTION
This adds an option to use a custom environment with `include`. When using a custom environment, the caller's environment is hidden from the loaded file.

Closes #29 